### PR TITLE
revert: chore: restrict build platforms to amd64

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -40,4 +40,4 @@ jobs:
           imageName: ghcr.io/${{ github.repository }}
           cacheFrom: ghcr.io/${{ github.repository }}
           push: always
-          platform: linux/amd64
+          platform: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
This reverts commit 633eb76c37b4ffe3f041b089bcb7df877a68ad1c.